### PR TITLE
Fix UnboundLocalError

### DIFF
--- a/additional/python/get_bookmarks.py
+++ b/additional/python/get_bookmarks.py
@@ -25,7 +25,7 @@ def main():
                 pass
  
     # Chromium/Chrome
-    entires = []
+    entries = []
     entries = jessentials.add_arrays(jfolders.get_folder_entries("~/.config/chromium/"), entries)
     entries = jessentials.add_arrays(jfolders.get_folder_entries("~/.config/google-chrome/"), entries)
     entries = jessentials.add_arrays(jfolders.get_folder_entries("~/.var/app/org.chromium.Chromium/config/chromium/"), entries)


### PR DESCRIPTION
Due to a typo the variable `entries` can be referenced before it is assigned, causing the error.

This only happens if the directory `~/.mozilla/firefox` does not exist. For example when Firefox is installed as Snap, where the actual path is `~/snap/firefox/common/.mozilla/firefox`.

This was tested on Ubuntu 22.04.1 LTS.

Best regards!