### PR TITLE
Feature: run executable files

### DIFF
--- a/additional/python/get_terminal_emulator.py
+++ b/additional/python/get_terminal_emulator.py
@@ -1,0 +1,27 @@
+# This script will enumerate a list of possibly installed
+# terminal emulators and will output the first one that is found in PATH.
+#
+# If you have more than one of these terminals installed,
+# set your preferred one as the first element of the list.
+
+import shutil
+
+terminal_emulators = [
+    "gnome-terminal",
+    "konsole",
+    "xfce4-terminal",
+    "tilix",
+    "alacritty",
+    "kitty",
+    "urxvt",
+    "rxvt",
+    "terminology",
+    "terminator",
+    "stterm",
+    "xterm"
+]
+
+for term in terminal_emulators:
+    if shutil.which(term) is not None:
+        print(term)
+        break

--- a/additional/python/get_terminal_emulator.py
+++ b/additional/python/get_terminal_emulator.py
@@ -10,14 +10,6 @@ terminal_emulators = [
     "gnome-terminal",
     "konsole",
     "xfce4-terminal",
-    "tilix",
-    "alacritty",
-    "kitty",
-    "urxvt",
-    "rxvt",
-    "terminology",
-    "terminator",
-    "stterm",
     "xterm"
 ]
 

--- a/lib/services/action_handler.dart
+++ b/lib/services/action_handler.dart
@@ -121,7 +121,20 @@ class ActionHandler {
 
     if (actionEntry.action.startsWith("openfile:")) {
       String file = actionEntry.action.replaceFirst("openfile:", "");
-      Linux.runCommandWithCustomArguments("xdg-open", [file]);
+      bool isExecutable = await Linux.isFileExecutable(file);
+      if (isExecutable) {
+        // TODO: Ask the user, if the file should be run (possible security risk).
+        // TODO: Ask the user, if the file should be run in a terminal.
+
+        // Run the file without terminal.
+        //Linux.runCommand(file);
+
+        // Run the file in a terminal (default for now).
+        Linux.runExecutableInTerminal(file);
+      } else {
+        Linux.runCommandWithCustomArguments("xdg-open", [file]);
+      }
+
       callback();
     }
 

--- a/lib/services/linux.dart
+++ b/lib/services/linux.dart
@@ -1377,4 +1377,24 @@ class Linux {
       default:
     }
   }
+
+  static Future<bool> isFileExecutable(String filePath) async {
+    var stat = await FileStat.stat(filePath);
+    var mode = stat.mode.toRadixString(8).substring(3);
+
+    // Example values for variable 'mode': '755', '644' etc.
+    // If any of the three numbers is uneven, the file is marked as executable.
+    return int.parse(mode[0]) % 2 != 0 ||
+        int.parse(mode[1]) % 2 != 0 ||
+        int.parse(mode[2]) % 2 != 0;
+  }
+
+  static void runExecutableInTerminal(String executablePath) async {
+    String term = await Linux.runPythonScript("get_terminal_emulator.py");
+    if ((term = term.trim()) == "gnome-terminal") {
+      Linux.runCommandWithCustomArguments(term, ["--", executablePath]);
+    } else {
+      Linux.runCommandWithCustomArguments(term, ["-e", executablePath]);
+    }
+  }
 }


### PR DESCRIPTION
Hello,

this commit makes it possible to run files, that are marked as executable (closes #43).

I believe this feature would affect scripts most of the time, so I decided to add an option for running the file in a terminal, so that the script output is visible. Determining the default terminal of the user is kind of difficult, because there is no standard between distributions. So the created python script will enumerate some terminal options and will output the first one that it finds.

Still this is kind of incomplete. The complete solution would be to ask the user if the file should be run and if it should be run in a terminal (like the dialog Linux Mint shows, if you double click an executable file).

To be honest, I have no clue about UI stuff in Flutter... so maybe this can be implemented at a later point in time?

Best regards.