### PR TITLE
Fix: use a different function to remove the .zip file extension

### DIFF
--- a/additional/python/jessentials.py
+++ b/additional/python/jessentials.py
@@ -153,7 +153,7 @@ def get_filename_of_path(path):
 # Returns the location of the new folder
 def unzip_file(file_path):
     file_name_zip = get_filename_of_path(file_path)
-    file_name = file_name_zip.replace(".zip", "")
+    file_name = os.path.splitext(file_name_zip)[0]
     path = file_path.replace(file_name_zip, "")
     run_command("mkdir %s%s" % (path, file_name), False)
     run_command("unzip -o %s -d %s%s" % (file_path, path, file_name), False)


### PR DESCRIPTION
Fixes #107 

The `replace` function replaces all instances for ".zip" in the file name, which can lead to wrong return values:

![replace-2](https://user-images.githubusercontent.com/117521599/226747862-823a08c0-2a30-41e8-bf50-63d477876517.png)

Using `os.path.splitext` solves this issue:

![replace-3](https://user-images.githubusercontent.com/117521599/226748031-38c259b5-4103-41db-926e-39b56c6b3a1d.png)

As far as I can tell `unzip_file` is never used in the application... so not really an urgent bug fix, but a fix none the less :P

Best regards!
