### PR TITLE
Disable search term and results feedback in home

### DIFF
--- a/lib/layouts/feedback/feedback_form.dart
+++ b/lib/layouts/feedback/feedback_form.dart
@@ -12,13 +12,17 @@ class FeedbackDialog extends StatefulWidget {
   String searchText;
   List<ActionEntry> foundEntries;
 
+  bool calledFromHome;
   bool includeSearchTermAndResults = true;
   bool includeBasicSystemInformation = true;
 
   String message = "";
 
   FeedbackDialog(
-      {super.key, this.searchText = "", this.foundEntries = const []});
+      {super.key,
+      required this.calledFromHome,
+      this.searchText = "",
+      this.foundEntries = const []});
 
   @override
   State<FeedbackDialog> createState() => _FeedbackDialogState();
@@ -58,20 +62,21 @@ class _FeedbackDialogState extends State<FeedbackDialog> {
               style: Theme.of(context).textTheme.bodyText1,
               controller: messageController,
             ),
-            Row(
-              children: [
-                Checkbox(
-                    activeColor: MintY.currentColor,
-                    value: widget.includeSearchTermAndResults,
-                    onChanged: ((value) => setState(() {
-                          widget.includeSearchTermAndResults = value!;
-                        }))),
-                Text(
-                  AppLocalizations.of(context)!.includeSearchTermAndResults,
-                  style: Theme.of(context).textTheme.bodyText1,
-                ),
-              ],
-            ),
+            if (!widget.calledFromHome)
+              Row(
+                children: [
+                  Checkbox(
+                      activeColor: MintY.currentColor,
+                      value: widget.includeSearchTermAndResults,
+                      onChanged: ((value) => setState(() {
+                            widget.includeSearchTermAndResults = value!;
+                          }))),
+                  Text(
+                    AppLocalizations.of(context)!.includeSearchTermAndResults,
+                    style: Theme.of(context).textTheme.bodyText1,
+                  ),
+                ],
+              ),
             Row(
               children: [
                 Checkbox(
@@ -116,7 +121,9 @@ class _FeedbackDialogState extends State<FeedbackDialog> {
                         widget.foundEntries,
                         widget.searchText,
                         widget.includeBasicSystemInformation,
-                        widget.includeSearchTermAndResults);
+                        widget.calledFromHome
+                            ? false
+                            : widget.includeSearchTermAndResults);
                     Navigator.of(context).pop();
                     showDialog(
                       context: context,

--- a/lib/layouts/main_screen/main_search.dart
+++ b/lib/layouts/main_screen/main_search.dart
@@ -187,6 +187,7 @@ class _MainSearchState extends State<MainSearch> {
                                 onPressed: () => showDialog(
                                   context: context,
                                   builder: (context) => FeedbackDialog(
+                                      calledFromHome: false,
                                       foundEntries: _foundEntries,
                                       searchText: _lastKeyword),
                                 ),
@@ -586,7 +587,9 @@ class FeedbackButton extends StatelessWidget {
       onPressed: () => showDialog(
         context: context,
         builder: (context) => FeedbackDialog(
-            foundEntries: _foundEntries, searchText: _lastKeyword),
+            calledFromHome: true,
+            foundEntries: _foundEntries,
+            searchText: _lastKeyword),
       ),
       padding: EdgeInsets.zero,
       tooltip: AppLocalizations.of(context)!.sendFeedback,


### PR DESCRIPTION
If the feedback widget is opened from the search home screen, the checkbox to enable the inclusion of the search term/results will not show and the option will default to `false` when sending feedback.

When opened from a search, the checkbox is visible and the user can make their choice as normal.

I hope this is what you had in mind?

Best regards!

closes #55 