### PR TITLE
Ignore efivarfs in disk analyzer

### DIFF
--- a/lib/linux/linux_filesystem.dart
+++ b/lib/linux/linux_filesystem.dart
@@ -22,7 +22,8 @@ abstract class LinuxFilesystem {
     "tmpfs",
     "/dev/loop",
     "revokefs-fuse",
-    "cgroup"
+    "cgroup",
+    "efivarfs"
   ];
 
   static final List<String> _removableDevices = ["/media/", "/mnt/"];


### PR DESCRIPTION
Added 'efivarfs' to the device ignore list.
Tested on openSUSE Tumbleweed.

Fixes: #173  

Best regards :)