### PR TITLE
Improve Arch Linux related code

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,36 +1,35 @@
 # Maintainer: Jean28518@Github
+
 pkgname=linux-assistant
-pkgdesc="A daily linux helper with powerful integrated search, routines and checks."
-pkgver=0.4.4
+pkgver=0.5.3
 pkgrel=1
+pkgdesc='A daily linux helper with powerful integrated search, routines and checks.'
 arch=('x86_64')
+url='https://www.linux-assistant.org'
 license=('GPL-3.0-or-later')
-
+depends=('libkeybinder3'
+        'wmctrl'
+        'wget'
+        'python'
+        'mesa-utils'
+        'polkit')
+options=('!debug')
 source=("https://github.com/Jean28518/linux-assistant/releases/latest/download/linux-assistant-bundle.zip")
-
-depends=("libkeybinder3" "wmctrl" "wget" "python" "mesa-utils" "polkit")
+sha256sums=('SKIP')
 
 package() {
-    mkdir -p "$pkgdir/usr/bin"
-    cp -f "$srcdir/linux-assistant-bundle/linux-assistant.sh" "$pkgdir/usr/bin/linux-assistant"
-    chmod +x "$pkgdir/usr/bin/linux-assistant"
+    cd linux-assistant-bundle
 
-    mkdir -p "$pkgdir/usr/share/polkit-1/actions"
-    cp -f "$srcdir/linux-assistant-bundle/org.linux-assistant.operations.policy" "$pkgdir/usr/share/polkit-1/actions/org.linux-assistant.operations.policy"
+    install -Dm755 linux-assistant.sh "$pkgdir/usr/bin/linux-assistant"
+    install -Dm644 org.linux-assistant.operations.policy "$pkgdir/usr/share/polkit-1/actions/org.linux-assistant.operations.policy"
+    install -Dm644 linux-assistant.desktop "$pkgdir/usr/share/applications/linux-assistant.desktop"
+    install -Dm644 linux-assistant.png "$pkgdir/usr/share/icons/hicolor/256x256/apps/linux-assistant.png"
 
-    mkdir -p "$pkgdir/usr/share/applications"
-    cp -f "$srcdir/linux-assistant-bundle/linux-assistant.desktop" "$pkgdir/usr/share/applications/linux-assistant.desktop"
+    install -dm755 "$pkgdir/usr/lib/linux-assistant"
+    cp -a lib "$pkgdir/usr/lib/linux-assistant/"
+    cp -a data "$pkgdir/usr/lib/linux-assistant/"
+    cp -a additional "$pkgdir/usr/lib/linux-assistant/"
 
-    mkdir -p "$pkgdir/usr/share/icons/hicolor/256x256/apps"
-    cp -f "$srcdir/linux-assistant-bundle/linux-assistant.png" "$pkgdir/usr/share/icons/hicolor/256x256/apps/linux-assistant.png"
-
-    mkdir -p "$pkgdir/usr/lib/linux-assistant"
-    cp -r "$srcdir/linux-assistant-bundle/lib" "$pkgdir/usr/lib/linux-assistant/"
-    cp -r "$srcdir/linux-assistant-bundle/data" "$pkgdir/usr/lib/linux-assistant/"
-    cp -r "$srcdir/linux-assistant-bundle/additional" "$pkgdir/usr/lib/linux-assistant/"
-    cp -f "$srcdir/linux-assistant-bundle/version" "$pkgdir/usr/lib/linux-assistant/"
-    cp -f "$srcdir/linux-assistant-bundle/linux-assistant" "$pkgdir/usr/lib/linux-assistant/"
-
-
-  tar -czf "$pkgname-$pkgver-$arch.pkg.tar.gz" -C "$pkgdir" .
+    install -Dm644 version "$pkgdir/usr/lib/linux-assistant/version"
+    install -Dm755 linux-assistant "$pkgdir/usr/lib/linux-assistant/linux-assistant"
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ bash ./build-rpm.sh
 # You can only do this on an arch based distro
 bash ./build-arch-pkg.sh
 # To Install:
-makepkg -s --skipchecksums --install
+sudo pacman -U linux-assistant-*.pkg.tar.zst
 ```
 
 ## Run as flatpak

--- a/additional/python/arch_checkupdates.py
+++ b/additional/python/arch_checkupdates.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+
+#   arch-checkupdates: Safely print a list of pending updates.
+
+import os
+import sys
+from subprocess import Popen, PIPE, DEVNULL
+
+def check_path(fspath: str, message: str):
+    if not os.path.exists(fspath):
+        sys.exit(message)
+
+def run_wait(exepath: str, args: list, err_raise = False, err_msg: str = f'run_wait: stderr') -> list:
+    check_path(exepath, f'run_wait: Cannot find exepath {exepath}')
+
+    process = Popen([exepath] + args, stdout=PIPE, stderr=PIPE)
+    stdout, stderr = process.communicate()
+
+    if err_raise:
+        if stderr:
+            sys.exit(err_msg)
+    return stdout.decode('utf-8').splitlines()
+
+def arch_checkupdates() -> list:
+    uid = os.getuid()
+    chkupdates_db = f'/tmp/checkup-db-{uid}'
+
+    if os.path.isfile(f'{chkupdates_db}/db.lck'):
+        os.remove(f'{chkupdates_db}/db.lck')
+
+    dbpath = run_wait('/usr/bin/pacman-conf', ['DBPath'])[0]
+    try:
+        check_path(dbpath, 'DB path not found')
+    except:
+        dbpath = '/var/lib/pacman/'
+
+    if not os.path.exists(chkupdates_db):
+        os.makedirs(chkupdates_db)
+    if not os.path.exists(f'{chkupdates_db}/local'):
+        os.symlink(f'{dbpath}/local', f'{chkupdates_db}/local', target_is_directory=True)
+    run_wait('/usr/bin/pacman', ['-Sy', '--dbpath', chkupdates_db, '--logfile', '/dev/null'], True,'Cannot fetch updates')
+
+    updates = list()
+    updates = run_wait('/usr/bin/pacman', ['-Qu', '--dbpath', chkupdates_db])
+    return updates

--- a/additional/python/check_security_arch.py
+++ b/additional/python/check_security_arch.py
@@ -3,6 +3,7 @@ import jessentials
 import jfolders
 import jfiles
 from check_home_folder_rights import check_home_folder_rights
+from arch_checkupdates import arch_checkupdates
 
 
 
@@ -15,8 +16,7 @@ def get_additional_sources():
         print("yayinstalled")
 
 def get_available_updates():
-    jessentials.run_command("pacman -Sy", False, False, {'DEBIAN_FRONTEND': 'noninteractive'})
-    lines = jessentials.run_command("pacman -Qu", False, True)
+    lines = arch_checkupdates()
     for line in lines:
         print(f"upgradeablepackage: {line}")
 

--- a/build-arch-pkg.sh
+++ b/build-arch-pkg.sh
@@ -1,6 +1,6 @@
 # Build bundle
 VERSION="$( cat version )"
 
-sed -i "s/pkgver=.*/pkgver=\"$VERSION\"/" PKGBUILD
+sed -i "s/pkgver=.*/pkgver=$VERSION/" PKGBUILD
 
-makepkg -s --skipchecksums
+makepkg -s

--- a/lib/services/action_handler.dart
+++ b/lib/services/action_handler.dart
@@ -292,7 +292,7 @@ class ActionHandler {
       Linux.commandQueue.add(LinuxCommand(
           userId: 0,
           command:
-              "${Linux.getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -S $pkg --noconfirm"));
+              "${Linux.getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -S --needed --noconfirm $pkg"));
       Navigator.push(
         context,
         MaterialPageRoute(
@@ -309,7 +309,7 @@ class ActionHandler {
       Linux.commandQueue.add(LinuxCommand(
           userId: 0,
           command:
-              "${Linux.getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -R $pkg --noconfirm"));
+              "${Linux.getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -Rs --noconfirm $pkg"));
       Navigator.push(
           context,
           MaterialPageRoute(

--- a/lib/services/linux.dart
+++ b/lib/services/linux.dart
@@ -370,7 +370,7 @@ class Linux {
           commandQueue.add(
             LinuxCommand(
               command:
-                  "${getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -S $appCode --noconfirm",
+                  "${getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -S --needed --noconfirm $appCode",
               userId: 0,
               environment: {},
             ),
@@ -554,7 +554,7 @@ class Linux {
             LinuxCommand(
               userId: 0,
               command:
-                  "${getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -R $appCode --noconfirm",
+                  "${getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -Rs --noconfirm $appCode",
             ),
           );
         }
@@ -681,9 +681,9 @@ class Linux {
 
   static Future<bool> isPacmanPackageAvailable(String appCode) async {
     String output = await runCommand(
-        "${getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -Ss $appCode");
-    return output.contains("community/$appCode") ||
-        output.contains("extra/$appCode");
+        "${getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -Si $appCode",
+        environment: {"LC_ALL": "C"});
+    return !output.contains("was not found");
   }
 
   /// returns the source under which the Flatpak is available, otherwise empty String
@@ -1158,7 +1158,7 @@ class Linux {
         commandQueue.add(LinuxCommand(
           userId: 0,
           command:
-              "${getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -S --noconfirm vlc gstreamer libdvdcss libdvdread libdvdnav ffmpeg gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly",
+              "${getExecutablePathOfSoftwareManager(SOFTWARE_MANAGERS.PACMAN)} -S --needed --noconfirm vlc gstreamer libdvdcss libdvdread libdvdnav ffmpeg gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly",
         ));
         break;
       default:


### PR DESCRIPTION
The goal is to improve the current code related to Arch Linux and its derivatives. The code was tested on EndeavourOS.

Firstly, the PKGBUILD file is changed so it corresponds to the suggested layout described in the Arch Linux wiki. The layout and  install process matches now the packaging guidelines (https://wiki.archlinux.org/title/PKGBUILD). The checksum parameter is now implemented in the PKGBUILD file. Please consider providing a real checksum for each release instead of skipping the checksum.

Furthermore, the pacman package handling code is now capable of not reinstalling packages if they are already installed.
Pacman also removes unused dependencies when uninstalling a package. This cleans up unused packages.

The package install detection for pacman was also rewritten because the old implementation had limitations with different repositories. The old implementation only filters for specific repositories and excludes custom repos, while the new code respects them.

Moreover, the current check update implementation for the security check is not recommended by Arch Linux because partial upgrades are not supported on a rolling distro. It can brick the system (https://wiki.archlinux.org/title/System_maintenance#Avoid_certain_pacman_commands). Instead a save way of checking updates is added to the code base, which will not touch the pacman system databases.